### PR TITLE
Change variable name ELIXIR_DOWNLOAD_SHA1 to ELIXIR_DOWNLOAD_SHA256

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -10,9 +10,9 @@ ENV MIX_REBAR=/usr/local/bin/rebar
 
 RUN set -xe \
         && ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/v${ELIXIR_VERSION}.tar.gz" \
-        && ELIXIR_DOWNLOAD_SHA1=c7c87983e03a1dcf20078141a22355e88dadb26b53d3f3f98b9a9268687f9e20 \
+        && ELIXIR_DOWNLOAD_SHA256=c7c87983e03a1dcf20078141a22355e88dadb26b53d3f3f98b9a9268687f9e20 \
         && curl -fsSL $ELIXIR_DOWNLOAD_URL -o elixir-src.tar.gz \
-        && echo "$ELIXIR_DOWNLOAD_SHA1 elixir-src.tar.gz" | sha256sum -c - \
+        && echo "$ELIXIR_DOWNLOAD_SHA256 elixir-src.tar.gz" | sha256sum -c - \
         && mkdir -p /usr/src/elixir-src \
         && tar -xzf elixir-src.tar.gz -C /usr/src/elixir-src --strip-components=1 \
         && rm elixir-src.tar.gz \


### PR DESCRIPTION
Super minor, but I was checking this repo out and saw that the name of the variable containing the download sha in the Elixir Dockerfile references sha1 when it really should be sha256.